### PR TITLE
remove files from package

### DIFF
--- a/BunyanLambdaLogger/BunyanLambdaLogger.csproj
+++ b/BunyanLambdaLogger/BunyanLambdaLogger.csproj
@@ -25,12 +25,6 @@
     <version>0.3.2</version>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../settings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
@@ -40,10 +34,5 @@
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\example-settings.json" />
-    <Content Include="..\LICENSE.TXT" />
-    <Content Include="..\README.md" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The additional files end up cluttering the view in IDEs.

For example, given a .csproj like this:

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>netcoreapp1.0</TargetFramework>
  </PropertyGroup>
  <ItemGroup>
    <PackageReference Include="TedNugetServer.BunyanLambdaLogger" Version="0.3.2" />
  </ItemGroup>
</Project>
```

I see the following in Visual Studio

![visual_studio](https://user-images.githubusercontent.com/1733241/30996852-a1fbbc36-a478-11e7-978d-3798b0ba658d.png)
