### PR TITLE
add eventId support for frameworks such as EF core

### DIFF
--- a/BunyanLambdaLogger.Tests/BunyanLambdaILoggerTests.cs
+++ b/BunyanLambdaLogger.Tests/BunyanLambdaILoggerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Xunit;
+using static BunyanLambdaLogger.Tests.BunyanLambdaLoggerExtensions;
 
 namespace BunyanLambdaLogger.Tests
 {
@@ -97,5 +98,44 @@ namespace BunyanLambdaLogger.Tests
       var logger = Logger.Create(conf, nameof(BunyanLambdaILoggerTests), "unit-tests");
       logger.LogCritical("Message with {0} {1}", new {property1 = "value 1"}, new Exception("Exception!"), "argument", "argument2");
     }
+
+    [Fact]
+    public void BunyanLambdaILogger_With_EventId()
+    {
+      var conf = new Dictionary<string, string>
+      {
+        {"Lambda.Logging:LogLevel:Default", "Information"}
+      };
+
+      var eventId = new EventId(1, "NewEvent");
+
+      // ReSharper disable once LocalVariableHidesMember
+      var logger = Logger.Create(conf, nameof(BunyanLambdaILoggerTests), "unit-tests");
+
+      var dataSet = TestCreateDataSet("unit-tests", "EF Core event", null);
+
+      logger.Log(logLevel: LogLevel.Information, eventId: eventId, state: dataSet, exception: null,
+        formatter: TestMessageFormatter);
+    }
+
+    [Fact]
+    public void BunyanLambdaILogger_Without_EventId()
+    {
+      var conf = new Dictionary<string, string>
+      {
+        {"Lambda.Logging:LogLevel:Default", "Information"}
+      };
+
+      var eventId = new EventId();
+
+      // ReSharper disable once LocalVariableHidesMember
+      var logger = Logger.Create(conf, nameof(BunyanLambdaILoggerTests), "unit-tests");
+
+      var dataSet = TestCreateDataSet("unit-tests", "EF Core event", null);
+
+      logger.Log(logLevel: LogLevel.Information, eventId: eventId, state: dataSet, exception: null,
+        formatter: TestMessageFormatter);
+    }
+
   }
 }

--- a/BunyanLambdaLogger.Tests/BunyanLambdaLoggerExtensions.cs
+++ b/BunyanLambdaLogger.Tests/BunyanLambdaLoggerExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Extensions.Logging.Internal;
+using Newtonsoft.Json.Linq;
+
+namespace BunyanLambdaLogger.Tests
+{
+  public static class BunyanLambdaLoggerExtensions
+  {
+    internal static JObject TestCreateDataSet(string message, object data, object[] args)
+    {
+      if (data != null && data.GetType().Name.ToLower() == "string")
+      {
+        args = args ?? new object[] { };
+        args = new[] {data}.Concat(args).ToArray();
+        data = null;
+      }
+
+      var dataSet = JObject.FromObject(data ?? new { });
+      dataSet.Add("msg", new FormattedLogValues(message, args).ToString());
+      return dataSet;
+    }
+
+    internal static string TestMessageFormatter(object state, Exception error)
+    {
+      return state.ToString();
+    }
+  }
+}

--- a/BunyanLambdaLogger/BunyanLambdaILogger.cs
+++ b/BunyanLambdaLogger/BunyanLambdaILogger.cs
@@ -123,7 +123,11 @@ namespace Microsoft.Extensions.Logging
 
       if (exception != null) message.err = JObject.FromObject(exception);
 
-      if (eventId.Id != 0) message.event_id = eventId;
+      if (eventId.Id != 0)
+      {
+        message.event_id = eventId.Id;
+        message.event_name = eventId.Name;
+      }
 
       message.v = 0;
 


### PR DESCRIPTION
Adds support for the `eventId` parameter, which will accommodate framework logs leveraging this value such as EF Core:

```
{"name":"ApplicationName.Foo","level":30,"category_name":"Microsoft.EntityFrameworkCore.Infrastructure","pid":86753,"hostname":"localhost","msg":"Entity Framework Core 2.0.0-rtm-26452 initialized 'TestContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer' with options: None","time":"2018-04-10T20:41:42.07952Z","event_id":100403,"event_name":"Microsoft.EntityFrameworkCore.Infrastructure.ContextInitialized","v":0}
{"name":"ApplicationName.Foo","level":30,"category_name":"Microsoft.EntityFrameworkCore.Database.Command","pid":86753,"hostname":"localhost","msg":"Executed DbCommand (83ms) [Parameters=[], CommandType='Text', CommandTimeout='30']\nSELECT [c].[Id], [c].[Name], [c].[TypeId], [h].[HostName], [c].[isActive]\nFROM (\n    SELECT c.Id, c.Name, c.TypeId, from Catalogs c LEFT OUTER JOIN Hosts h on c.HostId = h.Id\n) AS [c]\nWHERE ([c].[Id] > 0) AND ([c].[isActive] = 1)","time":"2018-04-10T20:41:42.552864Z","event_id":200101,"event_name":"Microsoft.EntityFrameworkCore.Database.Command.CommandExecuted","v":0}
```

Without these changes, the following error is thrown:
```
System.AggregateException : An error occurred while writing to logger(s). (Could not determine JSON object type for type Microsoft.Extensions.Logging.EventId.)
---- System.ArgumentException : Could not determine JSON object type for type Microsoft.Extensions.Logging.EventId.
   at Microsoft.Extensions.Logging.Logger.Log[TState](LogLevel logLevel, EventId eventId, TState state, Exception exception, Func`3 formatter)
   at BunyanLambdaLogger.Tests.BunyanLambdaILoggerTests.BunyanLambdaILogger_With_EventId() in /Development/BunyanLambdaLogger/BunyanLambdaLogger.Tests/BunyanLambdaILoggerTests.cs:line 117
----- Inner Stack Trace -----
   at Newtonsoft.Json.Linq.JValue.GetValueType(Nullable`1 current, Object value)
   at Newtonsoft.Json.Linq.JObject.JObjectDynamicProxy.TrySetMember(JObject instance, SetMemberBinder binder, Object value)
   at CallSite.Target(Closure , CallSite , Object , EventId )
   at CallSite.Target(Closure , CallSite , Object , EventId )
   at Microsoft.Extensions.Logging.BunyanLambdaILogger.Log[TState](LogLevel logLevel, EventId eventId, TState state, Exception exception, Func`3 formatter) in /Development/BunyanLambdaLogger/BunyanLambdaLogger/BunyanLambdaILogger.cs:line 126
   at Microsoft.Extensions.Logging.Logger.Log[TState](LogLevel logLevel, EventId eventId, TState state, Exception exception, Func`3 formatter)
```
